### PR TITLE
fix pyyaml / yaml config load

### DIFF
--- a/openldap_exporter.py
+++ b/openldap_exporter.py
@@ -145,7 +145,7 @@ parser.add_argument('--config',
                     required = True)
 arguments = parser.parse_args()
 
-config = yaml.load(arguments.config)
+config = yaml.safe_load(arguments.config)
 arguments.config.close()
 
 output = textFileLogObserver(sys.stderr, timeFormat='')


### PR DESCRIPTION
building with the last version of pyyaml, exporter fails to start:

```
Traceback (most recent call last):
  File "/usr/src/app/openldap_exporter.py", line 148, in <module>
    config = yaml.load(arguments.config)
TypeError: load() missing 1 required positional argument: 'Loader'
```

see https://stackoverflow.com/a/69581453/5607207